### PR TITLE
After token code review

### DIFF
--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -183,6 +183,11 @@ contract UBI is Initializable, ERC20BurnableUpgradeable, ERC20SnapshotUpgradeabl
     proofOfHumanity = _proofOfHumanity;
   }
 
+  /** @dev External function for Snapshot event emitter only accessible by governor.  */
+  function snapshot() external onlyByGovernor {
+    _snapshot();
+  }
+
   /* Getters */
 
   /** @dev Calculates how much UBI a submission has available for withdrawal.
@@ -198,8 +203,7 @@ contract UBI is Initializable, ERC20BurnableUpgradeable, ERC20SnapshotUpgradeabl
 
   /** Overrides */
 
-  /** @dev Overrides with Snapshot mechanisms _beforeTokenTransfer functions.
-  */
+  /** @dev Overrides with Snapshot mechanisms _beforeTokenTransfer functions.  */
   function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override(ERC20Upgradeable, ERC20SnapshotUpgradeable) {
     ERC20SnapshotUpgradeable._beforeTokenTransfer(from, to, amount);
   }

--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -49,7 +49,7 @@ contract UBI is Initializable, ERC20BurnableUpgradeable, ERC20SnapshotUpgradeabl
 
   /* Storage */
     
-  /// @dev How many tokens per second will be minted for every valid human proof per second.
+  /// @dev How many tokens per second will be minted for every valid human.
   uint256 public accruedPerSecond;
 
   /// @dev To prevent intrinsic risks of flash loan attacks it will restrict key functions to one per block.

--- a/test/UBI.proxy.js
+++ b/test/UBI.proxy.js
@@ -63,6 +63,16 @@ contract('UBI (Upgradeable Contract)', accounts => {
       expect((await ubi.accruedPerSecond()).toString()).to.equal('2');
     });
 
+    it("Allows the governor to emit `Snapshot` event.", async () => {
+      // Make sure it reverts if we are not the governor.
+      await expect(
+        ubi.connect(accounts[1]).snapshot()
+      ).to.be.revertedWith("The caller is not the governor.");
+
+      // Emit Snapshot from governor address
+      await expect(ubi.snapshot())
+        .to.emit(ubi, "Snapshot")
+    }); 
 
     it("Allows registered submissions to start accruing UBI.", async () => {
       // Check that the initial `lastMintedSecond` value is 0.


### PR DESCRIPTION
Exposes `Snapshot` event emitter as external.
Fixes to comments.
Keeps simplicity.