### PR TITLE
Fix Withdrawn Storage Statements

### DIFF
--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -115,7 +115,7 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable, ERC20Snapsho
     uint256 newSupply = getAccruedValue(human);
 
     accruedSince[human] = 0;
-    withdrawn[msg.sender] = newSupply;
+    withdrawn[human] = 0;
 
     _mint(msg.sender, newSupply);
 

--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -9,7 +9,7 @@ import "./Humanity.sol";
 
 
 contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable, ERC20SnapshotUpgradeable {
-  
+
   using SafeMath for uint256;
 
   /* Events */
@@ -90,7 +90,8 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable, ERC20Snapsho
   function mintAccrued(address human) external isRegistered(human, true) isAccruing(human, true) {
     uint256 newSupply = getAccruedValue(human);
 
-    withdrawn[human] = newSupply;
+    lastBlock[msg.sender] = block.number;
+    withdrawn[human] += newSupply;
 
     _mint(human, newSupply);
 

--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -90,7 +90,6 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable, ERC20Snapsho
   function mintAccrued(address human) external isRegistered(human, true) isAccruing(human, true) {
     uint256 newSupply = getAccruedValue(human);
 
-    lastBlock[msg.sender] = block.number;
     withdrawn[human] += newSupply;
 
     _mint(human, newSupply);

--- a/test/UBI.proxy.js
+++ b/test/UBI.proxy.js
@@ -115,6 +115,10 @@ contract('UBI.sol', accounts => {
       await network.provider.send("evm_increaseTime", [3600]);
       await network.provider.send("evm_mine");
       await ubi.mintAccrued(owner.address);
+      await ubi.mintAccrued(owner.address);
+      const currentBalance = await ubi.balanceOf(owner.address);
+      const withdrawnAmount = await ubi.withdrawn(owner.address);
+      expect (await ubi.withdrawn(owner.address)).to.be.equal(currentBalance.sub(initialBalance));
       const accruedSince = await ubi.accruedSince(owner.address);
       expect(await ubi.balanceOf(owner.address)).to.be.above(initialBalance);
       await network.provider.send("evm_increaseTime", [3600]);


### PR DESCRIPTION
Two fixes: 

- In `mintAccrued`; `withdrawn[human] += newSupply;` instead of `withdrawn[human] = newSupply;`

- In `reportRemoval`; `withdrawn[human] = 0;` instead of `withdrawn[msg.sender] = newSupply;`
Reason: We don't want to set `msg.sender`s withdrawn amount to the amount msg.sender earned by repoting a human.

Also edited a test case to fail for the bug in the first fix.

@santisiri