### PR TITLE
Streaming of UBI

### DIFF
--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -33,21 +33,6 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable {
     _;
   }
 
-  /** @dev is already accruing token subsidy
-  *  @param _human for the address of the human.
-  *  @param _accruing if it's actively accruing value.
-  */
-  modifier isAccruing(address _human, bool _accruing) {
-    bool accruing = accruedSince[_human] != 0;
-    require(
-      accruing == _accruing,
-      accruing
-        ? "The submission is already accruing UBI."
-        : "The submission is not accruing UBI."
-    );
-    _;
-  }
-
   /* Initalizer */
 
   /** @dev Constructor.
@@ -73,7 +58,8 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable {
   /** @dev Starts accruing UBI for a registered submission.
   *  @param _human The submission ID.
   */
-  function startAccruing(address _human) external isRegistered(_human, true) isAccruing(_human, false) {
+  function startAccruing(address _human) external isRegistered(_human, true) {
+    require(accruedSince[_human] == 0, "The submission is already accruing UBI.");
     accruedSince[_human] = block.timestamp;
   }
 
@@ -83,7 +69,8 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable {
   *  leftover accrued UBI.
   *  @param _human The submission ID.
   */
-  function reportRemoval(address _human) external isRegistered(_human, false) isAccruing(_human, true) {
+  function reportRemoval(address _human) external isRegistered(_human, false) {
+    require(accruedSince[_human] != 0, "The submission is not accruing UBI.");
     uint256 newSupply = getAccruedValue(_human);
 
     accruedSince[_human] = 0;

--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -131,7 +131,7 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable {
     uint256 totalAccrued = accruedPerSecond.mul(block.timestamp.sub(accruedSince[_human]));
 
     // If this human does not have started to accrue, or current available balance to withdraw is negative, return 0.
-    if (accruedSince[_human] == 0 || withdrawn[_human] >= totalAccrued) return 0;
+    if (accruedSince[_human] == 0 || withdrawn[_human] >= totalAccrued || proofOfHumanity.isRegistered(_human) == false) return 0;
 
     else return totalAccrued.sub(withdrawn[_human]);
   }

--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -11,19 +11,6 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable {
 
   using SafeMath for uint256;
 
-  /* Events */
-
-  /** @dev Emitted when UBI is minted or taken by a reporter.
-    *  @param _recipient The accruer of the UBI.
-    *  @param _beneficiary The withdrawer or taker.
-    *  @param _value The value withdrawn.
-    */
-  event Mint(
-      address indexed _recipient,
-      address indexed _beneficiary,
-      uint256 _value
-  );
-
   /* Storage */
 
   /// @dev How many tokens per second will be minted for every valid human.
@@ -103,15 +90,6 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable {
     withdrawn[_human] = 0;
 
     _mint(msg.sender, newSupply);
-
-    emit Mint(_human, msg.sender, newSupply);
-  }
-
-  /** @dev Changes `accruedPerSecond` to `_accruedPerSecond`.
-  *  @param _accruedPerSecond How much of the token is accrued per block.
-  */
-  function changeAccruedPerSecond(uint256 _accruedPerSecond) external onlyByGovernor {
-    accruedPerSecond = _accruedPerSecond;
   }
 
   /** @dev Changes `proofOfHumanity` to `_proofOfHumanity`.
@@ -168,7 +146,6 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable {
     if (newSupply > 0) {
       withdrawn[_human] += newSupply;
       _mint(_human, newSupply);
-      emit Mint(_human, _human, newSupply);
     }
   }
 }

--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -2,13 +2,12 @@
 pragma solidity 0.7.3;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20BurnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20SnapshotUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./Humanity.sol";
 
 
-contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable, ERC20SnapshotUpgradeable {
+contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable {
 
   using SafeMath for uint256;
 
@@ -122,11 +121,6 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable, ERC20Snapsho
     proofOfHumanity = _proofOfHumanity;
   }
 
-  /** @dev External function for Snapshot event emitter only accessible by governor.  */
-  function snapshot() external onlyByGovernor returns(uint256) {
-    return _snapshot();
-  }
-
   /* Getters */
 
   /** @dev Calculates how much UBI a submission has available for withdrawal.
@@ -157,10 +151,10 @@ contract UBI is ForHumans, Initializable, ERC20BurnableUpgradeable, ERC20Snapsho
   }
 
   /** @dev Overrides with Snapshot mechanisms _beforeTokenTransfer functions.  */
-  function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override(ERC20Upgradeable, ERC20SnapshotUpgradeable) {
+  function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
     _mintAccrued(from);
     _mintAccrued(to);
-    ERC20SnapshotUpgradeable._beforeTokenTransfer(from, to, amount);
+    super._beforeTokenTransfer(from, to, amount);
   }
 
   /** Internal */

--- a/test/UBI.proxy.js
+++ b/test/UBI.proxy.js
@@ -95,11 +95,46 @@ contract('UBI.sol', accounts => {
       ).to.be.revertedWith("The submission is already accruing UBI.");
     });
 
+    it("happy path - a submission removed from Proof of Humanity no longer accrues value.", async () => {
+      await network.provider.send("evm_increaseTime", [7200]);
+      await network.provider.send("evm_mine");
+      await setSubmissionIsRegistered(addresses[1], false);
+      await network.provider.send("evm_increaseTime", [3600]);
+      await network.provider.send("evm_mine");
+      expect((await ubi.balanceOf(addresses[1])).toString()).to.equal('0');
+    });
+
+    it("happy path - a submission with interrupted accruing still keeps withdrawn coins.", async () => {
+      await ubi.transfer(addresses[1], 555);
+      await setSubmissionIsRegistered(addresses[1], true);
+      await network.provider.send("evm_increaseTime", [7200]);
+      await network.provider.send("evm_mine");
+      await setSubmissionIsRegistered(addresses[1], false);
+      await network.provider.send("evm_increaseTime", [7200]);
+      await network.provider.send("evm_mine");
+      expect((await ubi.balanceOf(addresses[1])).toString()).to.equal('555');
+    });
+
+    it("happy path - a submission that natively accrued keeps transfered coins upon interruption.", async () => {
+      await setSubmissionIsRegistered(accounts[3].address, true);
+      expect((await ubi.balanceOf(accounts[3].address)).toString()).to.equal('0');
+      await ubi.startAccruing(accounts[3].address);
+      await network.provider.send("evm_increaseTime", [7200]);
+      await network.provider.send("evm_mine");
+      await ubi.connect(accounts[3]).transfer(addresses[1], 55);
+      expect((await ubi.balanceOf(addresses[1])).toString()).to.equal('610');
+    });
+
+    /**
+     * @summary: Deprecated.
     it("require fail - The submission is not registered in Proof Of Humanity.", async () => {
       // Make sure it reverts if the submission is not registered.
       await setSubmissionIsRegistered(addresses[1], false);
+      console.log(`ubi.balanceOf(addresses[1]):`);
+      console.log((await ubi.balanceOf(addresses[1])).toString());
+
       await expect(
-        ubi.mintAccrued(addresses[1])
+        ubi.balanceOf(addresses[1])
       ).to.be.revertedWith(
         "The submission is not registered in Proof Of Humanity."
       );
@@ -112,40 +147,60 @@ contract('UBI.sol', accounts => {
         ubi.mintAccrued(addresses[2])
       ).to.be.revertedWith("The submission is not accruing UBI.");
     });
-
-    it("happy path - allow minting of accrued UBI.", async () => {
+    */
+   
+    it("happy path - withdrawn tokens get persisted after a transfer.", async () => {
       // Make sure it accrues value with elapsed time
-      const [owner] = await ethers.getSigners();
+      const owner = accounts[4];
       await setSubmissionIsRegistered(owner.address, true);
       await ubi.startAccruing(owner.address);
       const initialBalance = await ubi.balanceOf(owner.address);
-      const initialMintedSecond = await ubi.accruedSince(owner.address);
       await network.provider.send("evm_increaseTime", [3600]);
       await network.provider.send("evm_mine");
-      await ubi.mintAccrued(owner.address);
-      await ubi.mintAccrued(owner.address);
       const currentBalance = await ubi.balanceOf(owner.address);
+      await ubi.connect(owner).transfer(addresses[5], 350);
       const withdrawnAmount = await ubi.withdrawn(owner.address);
-      expect (await ubi.withdrawn(owner.address)).to.be.equal(currentBalance.sub(initialBalance));
-      const accruedSince = await ubi.accruedSince(owner.address);
-      expect(await ubi.balanceOf(owner.address)).to.be.above(initialBalance);
-      await network.provider.send("evm_increaseTime", [3600]);
+      expect(withdrawnAmount.toNumber()).to.be.at.least((currentBalance.sub(initialBalance)).toNumber());
+    });
+
+    it("happy path - check that Mint and Transfer events get called when it corresponds.", async () => {
+      const owner = accounts[9];
+      const initialBalance = await ubi.balanceOf(owner.address);
+      await setSubmissionIsRegistered(owner.address, true);
+      await ubi.startAccruing(owner.address);
+      await network.provider.send("evm_increaseTime", [36000]);
       await network.provider.send("evm_mine");
-      await expect(ubi.mintAccrued(owner.address))
+      expect(await ubi.balanceOf(owner.address)).to.be.above(initialBalance);
+      await expect(ubi.connect(owner).transfer(addresses[8], 18000))
         .to.emit(ubi, "Mint")
+      await expect(ubi.connect(owner).transfer(addresses[8], 18000))
+        .to.emit(ubi, "Transfer")
+      await expect(ubi.connect(owner).burn(8000))
+        .to.emit(ubi, "Transfer")
+      await expect(ubi.connect(owner).burn(8000))
+        .to.emit(ubi, "Mint")
+      await setSubmissionIsRegistered(owner.address, false);
+      await expect(ubi.connect(owner).burn(8000))
+        .to.emit(ubi, "Transfer")
+      await expect(ubi.connect(owner).burn(8000))
+        .to.not.emit(ubi, "Mint")
+      await expect(ubi.connect(owner).transfer(addresses[8], 1000))
+        .to.not.emit(ubi, "Mint")
+      expect((await ubi.balanceOf(owner.address)).toNumber()).to.be.at.least(3000);
     });
 
     it("happy path - does not allow withdrawing a negative balance", async() => {
       // Make sure it accrues value with elapsed time
-      const [owner] = await ethers.getSigners();
+      const owner = accounts[10];
       await ubi.changeAccruedPerSecond(200000000000); // An arbitrary fast rate.
+      await setSubmissionIsRegistered(owner.address, true);
+      await ubi.startAccruing(owner.address);
       await network.provider.send("evm_increaseTime", [3600]);
       await network.provider.send("evm_mine");
-      await ubi.mintAccrued(owner.address);
-
+      await ubi.connect(owner).burn(0);
       await ubi.changeAccruedPerSecond(2); // An arbitrary slow rate.
       const initialBalance = await ubi.balanceOf(owner.address);
-      await ubi.mintAccrued(owner.address); // We expect this mint operation to mint 0 tokens because currently user has a negative amount available to withdraw.
+      await ubi.connect(owner).burn(0); // We expect this mint operation to mint 0 tokens because currently user has a negative amount available to withdraw.
       expect(await ubi.balanceOf(owner.address)).to.be.equal(initialBalance);
     })
 

--- a/test/UBI.proxy.js
+++ b/test/UBI.proxy.js
@@ -50,6 +50,8 @@ contract('UBI.sol', accounts => {
       expect((await ubi.accruedPerSecond()).toString()).to.equal('2');
     });
 
+    /**
+     * @summary: Deprecated. 
     it("happy path - allow governor to emit `Snapshot` event.", async () => {
       // Make sure it reverts if we are not the governor.
       await expect(
@@ -60,6 +62,7 @@ contract('UBI.sol', accounts => {
       await expect(ubi.snapshot())
         .to.emit(ubi, "Snapshot")
     });
+    */
 
     it("happy path - allow registered submissions to start accruing UBI.", async () => {
       // Check that the initial `accruedSince` value is 0.

--- a/test/UBI.proxy.js
+++ b/test/UBI.proxy.js
@@ -64,10 +64,11 @@ contract('UBI.sol', accounts => {
     });
     */
 
-    it("happy path - allow registered submissions to start accruing UBI.", async () => {
-      // Check that the initial `accruedSince` value is 0.
+    it("happy path - check that the initial `accruedSince` value is 0.", async () => {
       expect((await ubi.accruedSince(addresses[1])).toString()).to.equal('0');
+    });
 
+    it("require fail - The submission is not registered in Proof Of Humanity.", async () => {
       // Make sure it reverts if the submission is not registered.
       await setSubmissionIsRegistered(addresses[1], false);
       await expect(
@@ -75,15 +76,19 @@ contract('UBI.sol', accounts => {
       ).to.be.revertedWith(
         "The submission is not registered in Proof Of Humanity."
       );
+    });
 
+    it("happy path - allow registered submissions to start accruing UBI.", async () => {
       // Start accruing UBI and check that the current block number was set.
       await setSubmissionIsRegistered(addresses[1], true);
       await ubi.startAccruing(addresses[1]);
-      const lastMinted = await ubi.accruedSince(addresses[1]);
+      const accruedSince = await ubi.accruedSince(addresses[1]);
       expect((await ubi.accruedSince(addresses[1])).toString()).to.equal(
-        lastMinted.toString()
+        accruedSince.toString()
       );
+    });
 
+    it("require fail - The submission is already accruing UBI.", async () => {
       // Make sure it reverts if you try to accrue UBI while already accruing UBI.
       await expect(
         ubi.startAccruing(addresses[1])


### PR DESCRIPTION
- Removed the `mintAccrued` function and directly displays on `balanceOf` the accrued value for a verified submission.
- Removed the `Snapshot` functionality from `UBI.sol`
- Implemented test cases for verifying token balances that are being accrued in real time.
- Implemented optimizations referred on https://docs.google.com/document/d/1PfdWowMDtSxaXyqvtST_i3TkolM7V7Qont1gccHNhPI/edit#

This version of UBI only requires the user to call `startAccruing` and its token balance will update in real time. If the user is no longer in ProofOfHumanity, the accrued value will be lost and only the accrued tokens that where minted during an interaction (`transfer` or `burn`) while he was a verified submission will be kept on his balances.  