### PR TITLE
feat(UBI): add the possibility to change the governor

### DIFF
--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -139,6 +139,13 @@ contract UBI is Initializable {
     totalSupply = totalSupply.add(newSupply);
   }
 
+  /** @dev Changes `governor` to `_governor`.
+  *  @param _governor The address of the new governor.
+  */
+    function changeGovernor(address _governor) external onlyByGovernor {
+      governor = _governor;
+    }
+
   /** @dev Changes `proofOfHumanity` to `_proofOfHumanity`.
   *  @param _proofOfHumanity Registry that meets interface of Proof of Humanity.
   */

--- a/contracts/UBI.sol
+++ b/contracts/UBI.sol
@@ -142,9 +142,9 @@ contract UBI is Initializable {
   /** @dev Changes `governor` to `_governor`.
   *  @param _governor The address of the new governor.
   */
-    function changeGovernor(address _governor) external onlyByGovernor {
-      governor = _governor;
-    }
+  function changeGovernor(address _governor) external onlyByGovernor {
+    governor = _governor;
+  }
 
   /** @dev Changes `proofOfHumanity` to `_proofOfHumanity`.
   *  @param _proofOfHumanity Registry that meets interface of Proof of Humanity.


### PR DESCRIPTION
Currently there is no way to change the governor. It’s perhaps the desired behavior. Even if the contract is upgradable, it would be nice to be able to change the governor starting from the contract’s V1.